### PR TITLE
modified dockerfile of 1.1 version

### DIFF
--- a/mixmil_container/1.1/Dockerfile
+++ b/mixmil_container/1.1/Dockerfile
@@ -3,11 +3,10 @@ FROM ghtrecontainers/python-chainguard:latest
 LABEL Description="MixMIL environment"
 LABEL Author="Giuditta Clerici"
 LABEL Contact="giuditta.clerici@fht.org"
-LABEL version="1.0"
+LABEL version="1.1"
 
 COPY environment.yml /tmp/environment.yml
 
-WORKDIR /opt
 RUN micromamba install -y -n base -f /tmp/environment.yml && \
     git clone https://github.com/AIH-SGML/mixmil.git && cd mixmil && git checkout jan-dev && \
     micromamba run -n base pip install -e . && \


### PR DESCRIPTION
The jupyter-lab command does not work on TRE.
I tried removing this line from dockerfile:

WORKDIR /opt

(I noticed this was not present in your template). And I corrected the version name